### PR TITLE
Applying the new `UnexpectedCallsWereMade` function to this fork

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Client", func() {
 		})
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -95,7 +95,7 @@ var _ = Describe("Client", func() {
 		})
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -149,7 +149,7 @@ var _ = Describe("Client", func() {
 		})
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeTrue())
 			Expect(unexpectedCalls).ShouldNot(BeNil())
 		})
@@ -239,7 +239,7 @@ var _ = Describe("Client", func() {
 			Expect(getSet.Err()).NotTo(HaveOccurred())
 			Expect(getSet.Val()).To(Equal("1"))
 
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -256,7 +256,7 @@ var _ = Describe("Client", func() {
 			_ = client.Get(ctx, "key")
 			Expect(clientMock.ExpectationsWereMet()).To(HaveOccurred())
 
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 
@@ -274,7 +274,7 @@ var _ = Describe("Client", func() {
 			Expect(get.Err()).To(HaveOccurred())
 			Expect(get.Val()).To(Equal(""))
 
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeTrue())
 			Expect(unexpectedCalls).NotTo(BeNil())
 		})
@@ -291,7 +291,7 @@ var _ = Describe("Client", func() {
 		})
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -314,7 +314,7 @@ var _ = Describe("Client", func() {
 	Describe("work other match", func() {
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -363,7 +363,7 @@ var _ = Describe("Client", func() {
 	Describe("work error", func() {
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})

--- a/client_test.go
+++ b/client_test.go
@@ -38,6 +38,12 @@ var _ = Describe("Client", func() {
 			pipe = client.TxPipeline()
 		})
 
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+		})
+
 		It("tx pipeline order", func() {
 			get := pipe.Get(ctx, "key1")
 			hashGet := pipe.HGet(ctx, "hash_key", "hash_field")
@@ -88,6 +94,12 @@ var _ = Describe("Client", func() {
 			pipe = client.Pipeline()
 		})
 
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+		})
+
 		It("pipeline order", func() {
 			clientMock.MatchExpectationsInOrder(true)
 
@@ -134,6 +146,12 @@ var _ = Describe("Client", func() {
 			clientMock.ExpectWatch("key1", "key2")
 			clientMock.ExpectGet("key1").SetVal("1")
 			clientMock.ExpectSet("key2", "2", 1*time.Second).SetVal("OK")
+		})
+
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeTrue())
+			Expect(unexpectedCalls).ShouldNot(BeNil())
 		})
 
 		It("watch error", func() {
@@ -220,6 +238,10 @@ var _ = Describe("Client", func() {
 			getSet := client.GetSet(ctx, "key", "0")
 			Expect(getSet.Err()).NotTo(HaveOccurred())
 			Expect(getSet.Val()).To(Equal("1"))
+
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
 		})
 
 		It("surplus", func() {
@@ -234,6 +256,10 @@ var _ = Describe("Client", func() {
 			_ = client.Get(ctx, "key")
 			Expect(clientMock.ExpectationsWereMet()).To(HaveOccurred())
 
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+
 			_ = client.GetSet(ctx, "key", "0")
 		})
 
@@ -247,6 +273,10 @@ var _ = Describe("Client", func() {
 			get := client.HGet(ctx, "key", "field")
 			Expect(get.Err()).To(HaveOccurred())
 			Expect(get.Val()).To(Equal(""))
+
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeTrue())
+			Expect(unexpectedCalls).NotTo(BeNil())
 		})
 	})
 
@@ -258,6 +288,12 @@ var _ = Describe("Client", func() {
 			clientMock.ExpectSet("key", "1", 1*time.Second).SetVal("OK")
 			clientMock.ExpectGet("key").SetVal("1")
 			clientMock.ExpectGetSet("key", "0").SetVal("1")
+		})
+
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
 		})
 
 		It("ordinary", func() {
@@ -276,6 +312,12 @@ var _ = Describe("Client", func() {
 	})
 
 	Describe("work other match", func() {
+
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+		})
 
 		It("regexp match", func() {
 			clientMock.Regexp().ExpectSet("key", `^order_id_[0-9]{10}$`, 1*time.Second).SetVal("OK")
@@ -319,6 +361,12 @@ var _ = Describe("Client", func() {
 	})
 
 	Describe("work error", func() {
+
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clientMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+		})
 
 		It("set error", func() {
 			clientMock.ExpectGet("key").SetErr(errors.New("set error"))

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Cluster", func() {
 			Expect(getSet.Err()).NotTo(HaveOccurred())
 			Expect(getSet.Val()).To(Equal("1"))
 
-			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -67,7 +67,7 @@ var _ = Describe("Cluster", func() {
 			_ = client.Get(ctx, "key")
 			Expect(clusterMock.ExpectationsWereMet()).To(HaveOccurred())
 
-			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 
@@ -85,7 +85,7 @@ var _ = Describe("Cluster", func() {
 			Expect(get.Err()).To(HaveOccurred())
 			Expect(get.Val()).To(Equal(""))
 
-			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeTrue())
 			Expect(unexpectedCalls).NotTo(BeNil())
 		})
@@ -102,7 +102,7 @@ var _ = Describe("Cluster", func() {
 		})
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -125,7 +125,7 @@ var _ = Describe("Cluster", func() {
 	Describe("work other match", func() {
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})
@@ -174,7 +174,7 @@ var _ = Describe("Cluster", func() {
 	Describe("work error", func() {
 
 		AfterEach(func() {
-			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereMade()
 			Expect(hasUnexpectedCall).To(BeFalse())
 			Expect(unexpectedCalls).To(BeNil())
 		})

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -49,6 +49,10 @@ var _ = Describe("Cluster", func() {
 			getSet := client.GetSet(ctx, "key", "0")
 			Expect(getSet.Err()).NotTo(HaveOccurred())
 			Expect(getSet.Val()).To(Equal("1"))
+
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
 		})
 
 		It("surplus", func() {
@@ -63,6 +67,10 @@ var _ = Describe("Cluster", func() {
 			_ = client.Get(ctx, "key")
 			Expect(clusterMock.ExpectationsWereMet()).To(HaveOccurred())
 
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+
 			_ = client.GetSet(ctx, "key", "0")
 		})
 
@@ -76,6 +84,10 @@ var _ = Describe("Cluster", func() {
 			get := client.HGet(ctx, "key", "field")
 			Expect(get.Err()).To(HaveOccurred())
 			Expect(get.Val()).To(Equal(""))
+
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeTrue())
+			Expect(unexpectedCalls).NotTo(BeNil())
 		})
 	})
 
@@ -87,6 +99,12 @@ var _ = Describe("Cluster", func() {
 			clusterMock.ExpectSet("key", "1", 1*time.Second).SetVal("OK")
 			clusterMock.ExpectGet("key").SetVal("1")
 			clusterMock.ExpectGetSet("key", "0").SetVal("1")
+		})
+
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
 		})
 
 		It("ordinary", func() {
@@ -105,6 +123,12 @@ var _ = Describe("Cluster", func() {
 	})
 
 	Describe("work other match", func() {
+
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+		})
 
 		It("regexp match", func() {
 			clusterMock.Regexp().ExpectSet("key", `^order_id_[0-9]{10}$`, 1*time.Second).SetVal("OK")
@@ -148,6 +172,12 @@ var _ = Describe("Cluster", func() {
 	})
 
 	Describe("work error", func() {
+
+		AfterEach(func() {
+			hasUnexpectedCall, unexpectedCalls := clusterMock.UnexpectedCallsWereCalled()
+			Expect(hasUnexpectedCall).To(BeFalse())
+			Expect(unexpectedCalls).To(BeNil())
+		})
 
 		It("set error", func() {
 			clusterMock.ExpectGet("key").SetErr(errors.New("set error"))

--- a/example/example.go
+++ b/example/example.go
@@ -3,6 +3,7 @@ package example
 import (
 	"context"
 	"errors"
+	"log"
 	"time"
 
 	"github.com/go-redis/redismock/v9"
@@ -65,6 +66,14 @@ func example() {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		//error
 		panic(err)
+	}
+
+	//--------
+
+	//unexpected redis commands have been called
+	//returns true and the unexpected calls
+	if unexpected, calls := mock.UnexpectedCallsWereCalled(); unexpected {
+		log.Printf("Unexpected calls: %+v", calls)
 	}
 
 	//---------

--- a/example/example.go
+++ b/example/example.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/go-redis/redismock/v9"
+	"github.com/antonyho/redismock"
 )
 
 var _ = example
@@ -72,7 +72,7 @@ func example() {
 
 	//unexpected redis commands have been called
 	//returns true and the unexpected calls
-	if unexpected, calls := mock.UnexpectedCallsWereCalled(); unexpected {
+	if unexpected, calls := mock.UnexpectedCallsWereMade(); unexpected {
 		log.Printf("Unexpected calls: %+v", calls)
 	}
 

--- a/example/ordinary/main_test.go
+++ b/example/ordinary/main_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/go-redis/redismock/v9"
+	"github.com/antonyho/redismock"
 )
 
 func TestItemCacheFail(t *testing.T) {

--- a/expect.go
+++ b/expect.go
@@ -24,6 +24,10 @@ type baseMock interface {
 	// were met in order. If any of them was not met - an error is returned.
 	ExpectationsWereMet() error
 
+	// UnexpectedCallsWereCalled returns any unexpected calls which were made.
+	// If any unexpected call was made, a list of unexpected call redis.Cmder is returned.
+	UnexpectedCallsWereCalled() (bool, []redis.Cmder)
+
 	// MatchExpectationsInOrder gives an option whether to match all expectations in the order they were set or not.
 	MatchExpectationsInOrder(b bool)
 

--- a/expect.go
+++ b/expect.go
@@ -24,9 +24,9 @@ type baseMock interface {
 	// were met in order. If any of them was not met - an error is returned.
 	ExpectationsWereMet() error
 
-	// UnexpectedCallsWereCalled returns any unexpected calls which were made.
+	// UnexpectedCallsWereMade returns any unexpected calls which were made.
 	// If any unexpected call was made, a list of unexpected call redis.Cmder is returned.
-	UnexpectedCallsWereCalled() (bool, []redis.Cmder)
+	UnexpectedCallsWereMade() (bool, []redis.Cmder)
 
 	// MatchExpectationsInOrder gives an option whether to match all expectations in the order they were set or not.
 	MatchExpectationsInOrder(b bool)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-redis/redismock/v9
+module github.com/antonyho/redismock
 
 go 1.18
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
-github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -38,8 +38,6 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.25.0 h1:Vw7br2PCDYijJHSfBOWhov+8cAnUf8MfMaIOV323l6Y=
 github.com/onsi/gomega v1.25.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/redis/go-redis/v9 v9.0.3 h1:+7mmR26M0IvyLxGZUHxu4GiBkJkVDid0Un+j4ScYu4k=
-github.com/redis/go-redis/v9 v9.0.3/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/redis/go-redis/v9 v9.2.0 h1:zwMdX0A4eVzse46YN18QhuDiM4uf3JmkOB4VZrdt5uI=
 github.com/redis/go-redis/v9 v9.2.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/mock.go
+++ b/mock.go
@@ -405,9 +405,9 @@ func (m *mock) ExpectationsWereMet() error {
 	return nil
 }
 
-func (m *mock) UnexpectedCallsWereCalled() (bool, []redis.Cmder) {
+func (m *mock) UnexpectedCallsWereMade() (bool, []redis.Cmder) {
 	if m.parent != nil {
-		return m.parent.UnexpectedCallsWereCalled()
+		return m.parent.UnexpectedCallsWereMade()
 	}
 	return len(m.unexpected) > 0, m.unexpected
 }

--- a/mock.go
+++ b/mock.go
@@ -23,9 +23,10 @@ type mock struct {
 
 	parent *mock
 
-	factory  mockCmdable
-	client   redis.Cmdable
-	expected []expectation
+	factory    mockCmdable
+	client     redis.Cmdable
+	expected   []expectation
+	unexpected []redis.Cmder
 
 	strictOrder bool
 
@@ -180,6 +181,7 @@ func (m *mock) process(cmd redis.Cmder) (err error) {
 		}
 		err = fmt.Errorf(msg, cmd.Args())
 		cmd.SetErr(err)
+		m.unexpected = append(m.unexpected, cmd)
 		return err
 	}
 
@@ -362,6 +364,7 @@ func (m *mock) ClearExpect() {
 		return
 	}
 	m.expected = nil
+	m.unexpected = nil
 }
 
 func (m *mock) Regexp() *mock {
@@ -400,6 +403,13 @@ func (m *mock) ExpectationsWereMet() error {
 		}
 	}
 	return nil
+}
+
+func (m *mock) UnexpectedCallsWereCalled() (bool, []redis.Cmder) {
+	if m.parent != nil {
+		return m.parent.UnexpectedCallsWereCalled()
+	}
+	return len(m.unexpected) > 0, m.unexpected
 }
 
 func (m *mock) MatchExpectationsInOrder(b bool) {
@@ -2862,29 +2872,29 @@ func (m *mock) ExpectTSMRangeWithArgs(fromTimestamp int, toTimestamp int, filter
 }
 
 func (m *mock) ExpectTSMRevRange(fromTimestamp int, toTimestamp int, filterExpr []string) *ExpectedMapStringSliceInterface {
-    e := &ExpectedMapStringSliceInterface{}
-    e.cmd = m.factory.TSMRevRange(m.ctx, fromTimestamp, toTimestamp, filterExpr)
-    m.pushExpect(e)
-    return e
+	e := &ExpectedMapStringSliceInterface{}
+	e.cmd = m.factory.TSMRevRange(m.ctx, fromTimestamp, toTimestamp, filterExpr)
+	m.pushExpect(e)
+	return e
 }
 
 func (m *mock) ExpectTSMRevRangeWithArgs(fromTimestamp int, toTimestamp int, filterExpr []string, options *redis.TSMRevRangeOptions) *ExpectedMapStringSliceInterface {
-    e := &ExpectedMapStringSliceInterface{}
-    e.cmd = m.factory.TSMRevRangeWithArgs(m.ctx, fromTimestamp, toTimestamp, filterExpr, options)
-    m.pushExpect(e)
-    return e
+	e := &ExpectedMapStringSliceInterface{}
+	e.cmd = m.factory.TSMRevRangeWithArgs(m.ctx, fromTimestamp, toTimestamp, filterExpr, options)
+	m.pushExpect(e)
+	return e
 }
 
 func (m *mock) ExpectTSMGet(filters []string) *ExpectedMapStringSliceInterface {
-    e := &ExpectedMapStringSliceInterface{}
-    e.cmd = m.factory.TSMGet(m.ctx, filters)
-    m.pushExpect(e)
-    return e
+	e := &ExpectedMapStringSliceInterface{}
+	e.cmd = m.factory.TSMGet(m.ctx, filters)
+	m.pushExpect(e)
+	return e
 }
 
 func (m *mock) ExpectTSMGetWithArgs(filters []string, options *redis.TSMGetOptions) *ExpectedMapStringSliceInterface {
-    e := &ExpectedMapStringSliceInterface{}
-    e.cmd = m.factory.TSMGetWithArgs(m.ctx, filters, options)
-    m.pushExpect(e)
-    return e
+	e := &ExpectedMapStringSliceInterface{}
+	e.cmd = m.factory.TSMGetWithArgs(m.ctx, filters, options)
+	m.pushExpect(e)
+	return e
 }


### PR DESCRIPTION
We need the `UnexpectedCallsWereMade` function to check if any unexpected command was called in the mock Redis client.
This check cannot be simply verified returned error by using third party test suite framework. But the Redis client is being encapsulated into our service. And the error was handled by the service implementation.